### PR TITLE
Fix test on array.spec

### DIFF
--- a/lib/matchers/array.js
+++ b/lib/matchers/array.js
@@ -69,7 +69,7 @@ module.exports = factory({
         acc.errors = acc.errors.concat(result.errors)
       }
 
-      if (typeof result.value !== 'undefined') { acc.value.push(result.value); }
+      acc.value.push(result.value);
 
       return acc;
     }, {value: [], errors: []});

--- a/test/matchers/array.spec.js
+++ b/test/matchers/array.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undefined */
 require('../../lib/strummer');
 var array  = require('../../lib/matchers/array');
 var bool  = require('../../lib/matchers/boolean');


### PR DESCRIPTION
`undefined` is a valid value that can be returned by `safeParse`, so we should keep it.